### PR TITLE
[FIX] Switformat autocorrect to lint temporary

### DIFF
--- a/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
+++ b/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
@@ -486,7 +486,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat . --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat . --lint --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- #9  
- 밀러가 슬랙에 올린 [스레드](https://macro-ax16859.slack.com/archives/C042NQEEP26/p1668843921676109)

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
임시적으로 swiftformat의 build phase를 autocorrect에서 lint로 수정하였습니다.

![swiftformat_lint](https://user-images.githubusercontent.com/59143479/202842651-f29f70d6-c00b-427e-8ff5-0c65e9b74789.jpeg)


이제는 빌드시에 위와같이 Lint처럼 Warning만 뜨게됩니다.

## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
build phase를 추후에 commit 이전에 할지, 아니면 그냥 GitHub action 에서 swiftformat을 돌려 push하게 할지 고민중입니다.
저는 GitHub action에서 swiftformat을 돌리면 혹시 모를 오류에 대응하기 힘들어 git hook을 활용하여 commit 전에 자동화해서 swiftformat을 돌리는 게 어떨까 싶습니다.

## ⁴/₄ 다음으로 진행될 작업
- Script 실행 시점 변경하여 lint에서 autocorrect로 되돌리기