### PR TITLE
[FEAT] 타이머 기능 구현

### DIFF
--- a/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
+++ b/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		35BD550E2925FF10008F96AC /* BaseCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BD550B2925FF10008F96AC /* BaseCollectionViewCell.swift */; };
 		35BD550F2925FF10008F96AC /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BD550C2925FF10008F96AC /* BaseViewController.swift */; };
 		35BD551129260026008F96AC /* ImageLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BD551029260026008F96AC /* ImageLiteral.swift */; };
+		35BD55172928AA62008F96AC /* SirenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BD55162928AA62008F96AC /* SirenViewController.swift */; };
+		35BD551B2928AA9F008F96AC /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BD551A2928AA9F008F96AC /* ProgressBar.swift */; };
+		35BD551D2928AAAE008F96AC /* CountDownTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BD551C2928AAAE008F96AC /* CountDownTimer.swift */; };
 		B523CB2729264FCD00E39C9E /* .swiftformat in Resources */ = {isa = PBXBuildFile; fileRef = B523CB2629264FCD00E39C9E /* .swiftformat */; };
 /* End PBXBuildFile section */
 
@@ -84,6 +87,9 @@
 		35BD550B2925FF10008F96AC /* BaseCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewCell.swift; sourceTree = "<group>"; };
 		35BD550C2925FF10008F96AC /* BaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		35BD551029260026008F96AC /* ImageLiteral.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageLiteral.swift; sourceTree = "<group>"; };
+		35BD55162928AA62008F96AC /* SirenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SirenViewController.swift; sourceTree = "<group>"; };
+		35BD551A2928AA9F008F96AC /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
+		35BD551C2928AAAE008F96AC /* CountDownTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountDownTimer.swift; sourceTree = "<group>"; };
 		B523CB2629264FCD00E39C9E /* .swiftformat */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .swiftformat; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -276,6 +282,7 @@
 		35BD54F72925F605008F96AC /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				35BD55152928AA55008F96AC /* Siren */,
 				35BD54F92925FBAE008F96AC /* Main */,
 			);
 			path = Screen;
@@ -311,6 +318,32 @@
 			children = (
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		35BD55152928AA55008F96AC /* Siren */ = {
+			isa = PBXGroup;
+			children = (
+				35BD55182928AA8A008F96AC /* View */,
+				35BD55162928AA62008F96AC /* SirenViewController.swift */,
+				35BD551C2928AAAE008F96AC /* CountDownTimer.swift */,
+			);
+			path = Siren;
+			sourceTree = "<group>";
+		};
+		35BD55182928AA8A008F96AC /* View */ = {
+			isa = PBXGroup;
+			children = (
+				35BD55192928AA92008F96AC /* Component */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		35BD55192928AA92008F96AC /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				35BD551A2928AA9F008F96AC /* ProgressBar.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -487,6 +520,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat . --lint --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat  . --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -496,9 +530,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				35BD55052925FED5008F96AC /* UICollectionView+Extension.swift in Sources */,
+				35BD551B2928AA9F008F96AC /* ProgressBar.swift in Sources */,
 				35BD55032925FEC3008F96AC /* UIViewController+Extension.swift in Sources */,
 				35BD54FD2925FEA5008F96AC /* NSObject+Extension.swift in Sources */,
 				35BD55012925FEB5008F96AC /* Color+Extension.swift in Sources */,
+				35BD551D2928AAAE008F96AC /* CountDownTimer.swift in Sources */,
+				35BD55172928AA62008F96AC /* SirenViewController.swift in Sources */,
 				35BD551129260026008F96AC /* ImageLiteral.swift in Sources */,
 				35BD550D2925FF10008F96AC /* BaseTableViewCell.swift in Sources */,
 				35BD550F2925FF10008F96AC /* BaseViewController.swift in Sources */,

--- a/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
+++ b/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
@@ -520,8 +520,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat . --lint --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat  . --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat  . --lint --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
+++ b/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
@@ -521,6 +521,7 @@
 			shellPath = /bin/sh;
 			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat . --lint --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
 			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat  . --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat  . --lint --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/SecretAgent/SecretAgent/Global/Resource/Base.lproj/Main.storyboard
+++ b/SecretAgent/SecretAgent/Global/Resource/Base.lproj/Main.storyboard
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Sij-v2-cWH">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -9,16 +11,106 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="SecretAgent" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="132" y="-34"/>
+        </scene>
+        <!--Siren View Controller-->
+        <scene sceneID="tY4-EM-ZFf">
+            <objects>
+                <viewController id="Sij-v2-cWH" customClass="SirenViewController" customModule="SecretAgent" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="qwC-4y-5jr">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="80" translatesAutoresizingMaskIntoConstraints="NO" id="2Qp-Qg-31P">
+                                <rect key="frame" x="79.333333333333329" y="749" width="231.33333333333337" height="34.333333333333371"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aAT-u8-LGp">
+                                        <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="34.333333333333336"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="STOP">
+                                            <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="stopTimer:" destination="Sij-v2-cWH" eventType="touchUpInside" id="NUC-7a-IAH"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fsd-bO-9FO">
+                                        <rect key="frame" x="155.66666666666669" y="0.0" width="75.666666666666686" height="34.333333333333336"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="START">
+                                            <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="startTimer:" destination="Sij-v2-cWH" eventType="touchUpInside" id="C8N-di-2d2"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pfs-81-2qc" customClass="ProgressBar" customModule="SecretAgent" customModuleProvider="target">
+                                <rect key="frame" x="45" y="272" width="300" height="300"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="300" id="Gav-vA-qad"/>
+                                    <constraint firstAttribute="width" constant="300" id="dso-FX-bQg"/>
+                                </constraints>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="03f-Yn-RXx" userLabel="CounterView">
+                                <rect key="frame" x="121.33333333333333" y="403" width="147.66666666666669" height="38.333333333333314"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K0f-PN-FfA">
+                                        <rect key="frame" x="0.0" y="0.0" width="39.666666666666664" height="38.333333333333336"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="32"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pGV-mU-Pyr">
+                                        <rect key="frame" x="69.666666666666671" y="0.0" width="8.3333333333333286" height="38.333333333333336"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="32"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qgZ-fM-v2N">
+                                        <rect key="frame" x="108.00000000000001" y="0.0" width="39.666666666666671" height="38.333333333333336"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="32"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="2mc-Av-CN1"/>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="03f-Yn-RXx" firstAttribute="centerY" secondItem="pfs-81-2qc" secondAttribute="centerY" id="0Ap-cX-IMy"/>
+                            <constraint firstItem="2mc-Av-CN1" firstAttribute="bottom" secondItem="2Qp-Qg-31P" secondAttribute="bottom" constant="26.670000000000002" id="2o4-hv-jKD"/>
+                            <constraint firstItem="2Qp-Qg-31P" firstAttribute="centerX" secondItem="qwC-4y-5jr" secondAttribute="centerX" id="6ta-rJ-Sa5"/>
+                            <constraint firstItem="pfs-81-2qc" firstAttribute="centerY" secondItem="qwC-4y-5jr" secondAttribute="centerY" id="jGn-Os-CVo"/>
+                            <constraint firstItem="03f-Yn-RXx" firstAttribute="centerX" secondItem="qwC-4y-5jr" secondAttribute="centerX" id="u6A-0R-9Ng"/>
+                            <constraint firstItem="pfs-81-2qc" firstAttribute="centerX" secondItem="qwC-4y-5jr" secondAttribute="centerX" id="wKe-Rp-fmh"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="counterView" destination="03f-Yn-RXx" id="udP-6C-MhU"/>
+                        <outlet property="minutes" destination="K0f-PN-FfA" id="kA3-ns-ooH"/>
+                        <outlet property="progressBar" destination="pfs-81-2qc" id="EMQ-sF-zxn"/>
+                        <outlet property="seconds" destination="qgZ-fM-v2N" id="5JT-BW-sAb"/>
+                        <outlet property="startButton" destination="fsd-bO-9FO" id="3nE-mo-oQU"/>
+                        <outlet property="stopButton" destination="aAT-u8-LGp" id="6EX-dX-e59"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="P2y-Cu-ZEI" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1141.5384615384614" y="-34.123222748815166"/>
         </scene>
     </scenes>
 </document>

--- a/SecretAgent/SecretAgent/Global/Support/SceneDelegate.swift
+++ b/SecretAgent/SecretAgent/Global/Support/SceneDelegate.swift
@@ -17,12 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         //        guard let _ = (scene as? UIWindowScene) else { return }
     }
 
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-    }
+    func sceneDidDisconnect(_ scene: UIScene) {}
 
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
@@ -35,16 +30,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
+        guard let start = UserDefaults.standard.object(forKey: "sceneDidEnterBackground") as? Date else { return }
+        let interval = Int(Date().timeIntervalSince(start))
+        NotificationCenter.default.post(name: NSNotification.Name("sceneWillEnterForeground"), object: nil, userInfo: ["time": interval])
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
+        UserDefaults.standard.setValue(Date(), forKey: "sceneDidEnterBackground")
 
-        // Save changes in the application's managed object context when the application transitions to the background.
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
 }

--- a/SecretAgent/SecretAgent/Screen/Siren/CountDownTimer.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/CountDownTimer.swift
@@ -26,7 +26,6 @@ final class CountDownTimer {
 
     // 타이머 설정
     func setTimer(minutes: Int, seconds: Int) {
-
         let totalSeconds = minutes * 60 + seconds
         self.seconds = Double(totalSeconds)
         duration = Double(totalSeconds)

--- a/SecretAgent/SecretAgent/Screen/Siren/CountDownTimer.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/CountDownTimer.swift
@@ -26,12 +26,10 @@ final class CountDownTimer {
 
     // 타이머 설정
     func setTimer(minutes: Int, seconds: Int) {
-        let minutesToSeconds = minutes * 60
-        let secondsToSeconds = seconds
 
-        let seconds = secondsToSeconds + minutesToSeconds
-        self.seconds = Double(seconds)
-        duration = Double(seconds)
+        let totalSeconds = minutes * 60 + seconds
+        self.seconds = Double(totalSeconds)
+        duration = Double(totalSeconds)
 
         delegate?.countdownTime(time: timeString(time: TimeInterval(ceil(duration))))
     }

--- a/SecretAgent/SecretAgent/Screen/Siren/CountDownTimer.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/CountDownTimer.swift
@@ -37,7 +37,7 @@ final class CountDownTimer {
     }
 
     // 타이머 실행
-    private func runTimer() {
+    func runTimer() {
         timer = Timer.scheduledTimer(timeInterval: 0.01, target: self, selector: #selector(updateTimer), userInfo: nil, repeats: true) // 왜 0.01초로 했을까?
     }
 
@@ -56,11 +56,6 @@ final class CountDownTimer {
         timer.invalidate()
         duration = seconds
         delegate?.countdownTimerDone()
-    }
-
-    // 타이머 실행 버튼 클릭시
-    func start() {
-        runTimer()
     }
 
     // 타이머 일시정지 버튼 클릭시

--- a/SecretAgent/SecretAgent/Screen/Siren/CountDownTimer.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/CountDownTimer.swift
@@ -1,0 +1,84 @@
+//
+//  CountDownTimer.swift
+//  SecretAgent
+//
+//  Created by DaeSeong on 2022/11/19.
+//
+
+import UIKit
+
+protocol CountdownTimerDelegate: AnyObject {
+    func countdownTimerDone()
+    func countdownTime(time: (minutes: String, seconds: String))
+}
+
+final class CountDownTimer {
+    // MARK: - Properties
+
+    weak var delegate: CountdownTimerDelegate?
+
+    private var seconds = 0.0
+    var duration = 0.0
+
+    private var timer: Timer = .init()
+
+    // MARK: - Func
+
+    // 타이머 설정
+    func setTimer(minutes: Int, seconds: Int) {
+        let minutesToSeconds = minutes * 60
+        let secondsToSeconds = seconds
+
+        let seconds = secondsToSeconds + minutesToSeconds
+        self.seconds = Double(seconds)
+        duration = Double(seconds)
+
+        delegate?.countdownTime(time: timeString(time: TimeInterval(ceil(duration))))
+    }
+
+    // 타이머 실행
+    private func runTimer() {
+        timer = Timer.scheduledTimer(timeInterval: 0.01, target: self, selector: #selector(updateTimer), userInfo: nil, repeats: true) // 왜 0.01초로 했을까?
+    }
+
+    // 타이머 실시간 업데이트
+    @objc private func updateTimer() {
+        if duration <= 0.0 {
+            timerDone()
+        } else {
+            duration -= 0.01
+            delegate?.countdownTime(time: timeString(time: TimeInterval(ceil(duration))))
+        }
+    }
+
+    // 타이머 종료
+    private func timerDone() {
+        timer.invalidate()
+        duration = seconds
+        delegate?.countdownTimerDone()
+    }
+
+    // 타이머 실행 버튼 클릭시
+    func start() {
+        runTimer()
+    }
+
+    // 타이머 일시정지 버튼 클릭시
+    @objc func pause() {
+        timer.invalidate()
+    }
+
+    // 타이머 멈춤 버튼 클릭시
+    func stop() {
+        timer.invalidate()
+        duration = seconds
+        delegate?.countdownTime(time: timeString(time: TimeInterval(ceil(duration))))
+    }
+
+    // TimeIntervalToString
+    private func timeString(time: TimeInterval) -> (minutes: String, seconds: String) {
+        let minutes = Int(time) / 60 % 60
+        let seconds = Int(time) % 60
+        return (minutes: String(format: "%02d", minutes), seconds: String(format: "%02d", seconds))
+    }
+}

--- a/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
@@ -14,7 +14,7 @@ final class SirenViewController: BaseViewController {
     @IBOutlet var minutes: UILabel!
 
     @IBOutlet var seconds: UILabel!
-
+    // FIXME: - startButton은 임시코드
     @IBOutlet var startButton: UIButton!
     @IBOutlet var stopButton: UIButton!
     @IBOutlet var progressBar: ProgressBar!
@@ -97,7 +97,7 @@ final class SirenViewController: BaseViewController {
         stopButton.alpha = 1.0
 
         if !countdownTimerDidStart {
-            countdownTimer.start()
+            countdownTimer.runTimer()
             progressBar.start()
             countdownTimerDidStart = true
             startButton.setTitle("PAUSE", for: .normal)

--- a/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
@@ -1,0 +1,129 @@
+//
+//  SirenViewController.swift
+//  SecretAgent
+//
+//  Created by DaeSeong on 2022/11/19.
+//
+
+import SnapKit
+import UIKit
+
+final class SirenViewController: BaseViewController {
+    // MARK: - Properties
+
+    @IBOutlet var minutes: UILabel!
+
+    @IBOutlet var seconds: UILabel!
+
+    @IBOutlet var startButton: UIButton!
+    @IBOutlet var stopButton: UIButton!
+    @IBOutlet var progressBar: ProgressBar!
+    @IBOutlet var counterView: UIStackView!
+
+    private let countdownTimer: CountDownTimer = .init()
+
+    private let doneLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 24.0,
+                                       weight: UIFont.Weight.light)
+        label.textColor = UIColor.white
+        label.textAlignment = .center
+        label.text = "Done!"
+        return label
+    }()
+
+    private var countdownTimerDidStart = false
+    private let selectedSecs: Int = 30 * 60
+
+    // MARK: - Life Cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setDelegation()
+        setNotification()
+    }
+
+    override func render() {
+        view.addSubview(doneLabel)
+        doneLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.centerY.equalToSuperview()
+        }
+    }
+
+    override func configUI() {
+        super.configUI()
+        countdownTimer.setTimer(minutes: 0, seconds: selectedSecs)
+        progressBar.setProgressBar(minutes: 0, seconds: selectedSecs)
+        stopButton.isEnabled = false
+        stopButton.alpha = 0.5
+        doneLabel.isHidden = true
+        counterView.isHidden = false
+
+        minutes.text = String(format: "%02d", selectedSecs / 60 % 60)
+        seconds.text = String(format: "%02d", selectedSecs % 60)
+    }
+
+    // MARK: - Func
+
+    private func setDelegation() {
+        countdownTimer.delegate = self
+    }
+
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(addBackgroundTime(_:)), name: NSNotification.Name("sceneWillEnterForeground"), object: nil)
+    }
+
+    @objc func addBackgroundTime(_ notification: Notification) {
+        if countdownTimerDidStart == true {
+            let time = notification.userInfo?["time"] as? Int ?? 0
+            countdownTimer.duration -= Double(time)
+        }
+    }
+
+    @IBAction func stopTimer(_ sender: UIButton) {
+        countdownTimer.stop()
+        progressBar.stop()
+        countdownTimerDidStart = false
+        stopButton.isEnabled = false
+        stopButton.alpha = 0.5
+        startButton.setTitle("START", for: .normal)
+    }
+
+    @IBAction func startTimer(_ sender: UIButton) {
+        doneLabel.isHidden = true
+        counterView.isHidden = false
+        stopButton.isEnabled = true
+        stopButton.alpha = 1.0
+
+        if !countdownTimerDidStart {
+            countdownTimer.start()
+            progressBar.start()
+            countdownTimerDidStart = true
+            startButton.setTitle("PAUSE", for: .normal)
+        } else {
+            countdownTimer.pause()
+            progressBar.pause()
+            countdownTimerDidStart = false
+            startButton.setTitle("RESUME", for: .normal)
+        }
+    }
+}
+
+// MARK: CountdownTimerDelegate
+
+extension SirenViewController: CountdownTimerDelegate {
+    func countdownTime(time: (minutes: String, seconds: String)) {
+        minutes.text = time.minutes
+        seconds.text = time.seconds
+    }
+
+    func countdownTimerDone() {
+        doneLabel.isHidden = false
+        counterView.isHidden = true
+        stopButton.isEnabled = false
+        stopButton.alpha = 0.5
+        startButton.setTitle("START", for: .normal)
+        countdownTimerDidStart = false
+    }
+}

--- a/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
@@ -26,7 +26,7 @@ final class SirenViewController: BaseViewController {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 24.0,
                                        weight: UIFont.Weight.light)
-        label.textColor = UIColor.white
+        label.textColor = .white
         label.textAlignment = .center
         label.text = "Done!"
         return label
@@ -46,8 +46,7 @@ final class SirenViewController: BaseViewController {
     override func render() {
         view.addSubview(doneLabel)
         doneLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.centerY.equalToSuperview()
+            make.center.equalToSuperview()
         }
     }
 

--- a/SecretAgent/SecretAgent/Screen/Siren/View/Component/ProgressBar.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/View/Component/ProgressBar.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-private enum Size {
+private enum ProgressBarSize {
     static let startAngle = Double(-Double.pi / 2)
     static let endAngle = Double(3 * Double.pi / 2)
 }
@@ -43,8 +43,8 @@ final class ProgressBar: UIView, CAAnimationDelegate {
         foregroundProgressLayer.path = UIBezierPath(
             arcCenter: centerPoint,
             radius: frame.width / 2 - 30.0,
-            startAngle: Size.startAngle,
-            endAngle: Size.endAngle,
+            startAngle: ProgressBarSize.startAngle,
+            endAngle: ProgressBarSize.endAngle,
             clockwise: true
         ).cgPath
         foregroundProgressLayer.configProgressBar(
@@ -58,8 +58,8 @@ final class ProgressBar: UIView, CAAnimationDelegate {
         backgroundProgressLayer.path = UIBezierPath(
             arcCenter: centerPoint,
             radius: frame.width / 2 - 30.0,
-            startAngle: Size.startAngle,
-            endAngle: Size.endAngle,
+            startAngle: ProgressBarSize.startAngle,
+            endAngle: ProgressBarSize.endAngle,
             clockwise: true
         ).cgPath
         backgroundProgressLayer.configProgressBar(

--- a/SecretAgent/SecretAgent/Screen/Siren/View/Component/ProgressBar.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/View/Component/ProgressBar.swift
@@ -80,8 +80,8 @@ final class ProgressBar: UIView, CAAnimationDelegate {
     private func startAnimation() {
         resetAnimation()
         animation.keyPath = "strokeEnd"
-        animation.fromValue = Double(0.0)
-        animation.toValue = Double(1.0)
+        animation.fromValue = 0.0
+        animation.toValue = 1.0
         animation.duration = CFTimeInterval(timerDuration)
         animation.delegate = self
         animation.isRemovedOnCompletion = false
@@ -147,7 +147,7 @@ extension CAShapeLayer {
     func configProgressBar(strokeColor: CGColor, strokeEnd: Double) {
         self.strokeColor = strokeColor
         backgroundColor = UIColor.clear.cgColor
-        fillColor = nil
+        fillColor = UIColor.clear.cgColor
         lineWidth = 24.0
         strokeStart = 0.0
         self.strokeEnd = strokeEnd

--- a/SecretAgent/SecretAgent/Screen/Siren/View/Component/ProgressBar.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/View/Component/ProgressBar.swift
@@ -1,0 +1,162 @@
+//
+//  ProgressBar.swift
+//  SecretAgent
+//
+//  Created by DaeSeong on 2022/11/19.
+//
+
+import UIKit
+
+private enum Size {
+    static let startAngle = Double(-Double.pi / 2)
+    static let endAngle = Double(3 * Double.pi / 2)
+}
+
+final class ProgressBar: UIView, CAAnimationDelegate {
+    // MARK: - Properties
+
+    private var animation = CABasicAnimation()
+    private var animationDidStart = false
+    private var timerDuration = 0
+    private let foregroundProgressLayer: CAShapeLayer = .init()
+    private let backgroundProgressLayer: CAShapeLayer = .init()
+
+    private lazy var centerPoint = CGPoint(x: frame.width / 2,
+                                           y: frame.height / 2)
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        loadBackgroundProgressBar()
+        loadForegroundProgressBar()
+    }
+
+    // MARK: - Func
+
+    private func loadForegroundProgressBar() {
+        foregroundProgressLayer.path = UIBezierPath(
+            arcCenter: centerPoint,
+            radius: frame.width / 2 - 30.0,
+            startAngle: Size.startAngle,
+            endAngle: Size.endAngle,
+            clockwise: true
+        ).cgPath
+        foregroundProgressLayer.configProgressBar(
+            strokeColor: UIColor.blue.cgColor,
+            strokeEnd: 0.0
+        )
+        backgroundProgressLayer.addSublayer(foregroundProgressLayer)
+    }
+
+    private func loadBackgroundProgressBar() {
+        backgroundProgressLayer.path = UIBezierPath(
+            arcCenter: centerPoint,
+            radius: frame.width / 2 - 30.0,
+            startAngle: Size.startAngle,
+            endAngle: Size.endAngle,
+            clockwise: true
+        ).cgPath
+        backgroundProgressLayer.configProgressBar(
+            strokeColor: UIColor.gray.cgColor,
+            strokeEnd: 1.0
+        )
+        layer.addSublayer(backgroundProgressLayer)
+    }
+
+    // 프로그래스바 설정
+    func setProgressBar(minutes: Int, seconds: Int) {
+        let minutesToSeconds = minutes * 60
+        let totalSeconds = seconds + minutesToSeconds
+        timerDuration = totalSeconds
+    }
+
+    // 애니메이션 시작
+    private func startAnimation() {
+        resetAnimation()
+        animation.keyPath = "strokeEnd"
+        animation.fromValue = Double(0.0)
+        animation.toValue = Double(1.0)
+        animation.duration = CFTimeInterval(timerDuration)
+        animation.delegate = self
+        animation.isRemovedOnCompletion = false
+        animation.isAdditive = true
+        animation.fillMode = CAMediaTimingFillMode.forwards
+        foregroundProgressLayer.add(animation, forKey: "strokeEnd")
+        animationDidStart = true
+    }
+
+    // 애니메이션 초기화
+    private func resetAnimation() {
+        foregroundProgressLayer.configForAnimation()
+        animationDidStart = false
+    }
+
+    // 애니메이션 멈춤
+    private func stopAnimation() {
+        foregroundProgressLayer.configForAnimation()
+        foregroundProgressLayer.removeAllAnimations()
+        animationDidStart = false
+    }
+
+    // 애니메이션 일시정지
+    private func pauseAnimation() {
+        let pausedTime = foregroundProgressLayer.convertTime(CACurrentMediaTime(), from: nil)
+        foregroundProgressLayer.speed = 0.0
+        foregroundProgressLayer.timeOffset = pausedTime
+    }
+
+    // 애니메이션 재개
+    private func resumeAnimation() {
+        let pausedTime = foregroundProgressLayer.timeOffset
+        foregroundProgressLayer.speed = 1.0
+        foregroundProgressLayer.timeOffset = 0.0
+        foregroundProgressLayer.beginTime = 0.0
+        let timeSincePause = foregroundProgressLayer.convertTime(CACurrentMediaTime(), from: nil) - pausedTime
+        foregroundProgressLayer.beginTime = timeSincePause
+    }
+
+    // 시작 버튼 클릭시
+    func start() {
+        if !animationDidStart {
+            startAnimation()
+        } else {
+            resumeAnimation()
+        }
+    }
+
+    // 일시정지 버튼 클릭시
+    func pause() {
+        pauseAnimation()
+    }
+
+    // 멈춤 버튼 클릭시
+    func stop() {
+        stopAnimation()
+    }
+}
+
+// MARK: - CAShapeLayer
+
+extension CAShapeLayer {
+    func configProgressBar(strokeColor: CGColor, strokeEnd: Double) {
+        self.strokeColor = strokeColor
+        backgroundColor = UIColor.clear.cgColor
+        fillColor = nil
+        lineWidth = 24.0
+        strokeStart = 0.0
+        self.strokeEnd = strokeEnd
+    }
+
+    func configForAnimation() {
+        speed = 1.0
+        timeOffset = 0.0
+        beginTime = 0.0
+        strokeEnd = 0.0
+    }
+}


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #4 
## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 빠른 UI구현을 위해서 스토리보드에서 작업을 해보았습니다.
- 프로그래스바를 구현하였습니다.
- 타이머 기능을 구현하였고, 앱이 백그라운드 상태여서 포그라운드 상태로 돌아올 때도 타이머 기능이 작동되도록 구현하였습니다.
<img width="379" alt="image" src="https://user-images.githubusercontent.com/69894461/202848707-780682ef-6883-405e-a28d-4894da96f2b0.png">


## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
- 카운트 타이머가 작동하는 중에 앱이 완전히 종료되고 다시 들어왔을 때도 타이머 기능이 재개되도록 해야할지 고민입니다.

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 앱 완전히 종료후 재접속시 타이머 기능 재개
