### PR TITLE
[FIX] 타이머가 끝나고 다음에 start 를 누를때 애니메이션이 채워지지 않는 버그

### DIFF
--- a/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
+++ b/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat . --lint --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat . --lint  --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
+++ b/SecretAgent/SecretAgent.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat . --lint  --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat > /dev/null; then\n  swiftformat . --lint --swiftversion 5.7\nelse\n  echo \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n  exit 1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/SecretAgent/SecretAgent/Global/Resource/Base.lproj/Main.storyboard
+++ b/SecretAgent/SecretAgent/Global/Resource/Base.lproj/Main.storyboard
@@ -56,14 +56,6 @@
                                     </button>
                                 </subviews>
                             </stackView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pfs-81-2qc" customClass="ProgressBar" customModule="SecretAgent" customModuleProvider="target">
-                                <rect key="frame" x="45" y="272" width="300" height="300"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="300" id="Gav-vA-qad"/>
-                                    <constraint firstAttribute="width" constant="300" id="dso-FX-bQg"/>
-                                </constraints>
-                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="03f-Yn-RXx" userLabel="CounterView">
                                 <rect key="frame" x="121.33333333333333" y="403" width="147.66666666666669" height="38.333333333333314"/>
                                 <subviews>
@@ -91,18 +83,15 @@
                         <viewLayoutGuide key="safeArea" id="2mc-Av-CN1"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="03f-Yn-RXx" firstAttribute="centerY" secondItem="pfs-81-2qc" secondAttribute="centerY" id="0Ap-cX-IMy"/>
                             <constraint firstItem="2mc-Av-CN1" firstAttribute="bottom" secondItem="2Qp-Qg-31P" secondAttribute="bottom" constant="26.670000000000002" id="2o4-hv-jKD"/>
                             <constraint firstItem="2Qp-Qg-31P" firstAttribute="centerX" secondItem="qwC-4y-5jr" secondAttribute="centerX" id="6ta-rJ-Sa5"/>
-                            <constraint firstItem="pfs-81-2qc" firstAttribute="centerY" secondItem="qwC-4y-5jr" secondAttribute="centerY" id="jGn-Os-CVo"/>
-                            <constraint firstItem="03f-Yn-RXx" firstAttribute="centerX" secondItem="qwC-4y-5jr" secondAttribute="centerX" id="u6A-0R-9Ng"/>
-                            <constraint firstItem="pfs-81-2qc" firstAttribute="centerX" secondItem="qwC-4y-5jr" secondAttribute="centerX" id="wKe-Rp-fmh"/>
+                            <constraint firstItem="03f-Yn-RXx" firstAttribute="centerY" secondItem="qwC-4y-5jr" secondAttribute="centerY" id="8a0-sb-BGp"/>
+                            <constraint firstItem="03f-Yn-RXx" firstAttribute="centerX" secondItem="qwC-4y-5jr" secondAttribute="centerX" id="cy7-Oe-wZ4"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="counterView" destination="03f-Yn-RXx" id="udP-6C-MhU"/>
                         <outlet property="minutes" destination="K0f-PN-FfA" id="kA3-ns-ooH"/>
-                        <outlet property="progressBar" destination="pfs-81-2qc" id="EMQ-sF-zxn"/>
                         <outlet property="seconds" destination="qgZ-fM-v2N" id="5JT-BW-sAb"/>
                         <outlet property="startButton" destination="fsd-bO-9FO" id="3nE-mo-oQU"/>
                         <outlet property="stopButton" destination="aAT-u8-LGp" id="6EX-dX-e59"/>

--- a/SecretAgent/SecretAgent/Global/Support/SceneDelegate.swift
+++ b/SecretAgent/SecretAgent/Global/Support/SceneDelegate.swift
@@ -31,7 +31,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneWillEnterForeground(_ scene: UIScene) {
         guard let start = UserDefaults.standard.object(forKey: "sceneDidEnterBackground") as? Date else { return }
-        let interval = Int(Date().timeIntervalSince(start))
+        let interval = Double(Date().timeIntervalSince(start))
         NotificationCenter.default.post(name: NSNotification.Name("sceneWillEnterForeground"), object: nil, userInfo: ["time": interval])
     }
 

--- a/SecretAgent/SecretAgent/Screen/Siren/CountDownTimer.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/CountDownTimer.swift
@@ -17,25 +17,28 @@ final class CountDownTimer {
 
     weak var delegate: CountdownTimerDelegate?
 
-    private var seconds = 0.0
-    var duration = 0.0
+    private let totalSeconds: Int
+    var duration: Double = 0.0
 
     private var timer: Timer = .init()
+
+    // MARK: - Init
+
+    init(totalSeconds: Int) {
+        self.totalSeconds = totalSeconds
+        duration = Double(totalSeconds)
+    }
 
     // MARK: - Func
 
     // 타이머 설정
-    func setTimer(minutes: Int, seconds: Int) {
-        let totalSeconds = minutes * 60 + seconds
-        self.seconds = Double(totalSeconds)
-        duration = Double(totalSeconds)
-
+    func setTimer() {
         delegate?.countdownTime(time: timeString(time: TimeInterval(ceil(duration))))
     }
 
     // 타이머 실행
     func runTimer() {
-        timer = Timer.scheduledTimer(timeInterval: 0.01, target: self, selector: #selector(updateTimer), userInfo: nil, repeats: true) // 왜 0.01초로 했을까?
+        timer = Timer.scheduledTimer(timeInterval: 0.01, target: self, selector: #selector(updateTimer), userInfo: nil, repeats: true)
     }
 
     // 타이머 실시간 업데이트
@@ -51,25 +54,25 @@ final class CountDownTimer {
     // 타이머 종료
     private func timerDone() {
         timer.invalidate()
-        duration = seconds
+        duration = Double(totalSeconds)
         delegate?.countdownTimerDone()
     }
 
     // 타이머 일시정지 버튼 클릭시
-    @objc func pause() {
+    func pause() {
         timer.invalidate()
     }
 
     // 타이머 멈춤 버튼 클릭시
     func stop() {
         timer.invalidate()
-        duration = seconds
+        duration = Double(totalSeconds)
         delegate?.countdownTime(time: timeString(time: TimeInterval(ceil(duration))))
     }
 
     // TimeIntervalToString
     private func timeString(time: TimeInterval) -> (minutes: String, seconds: String) {
-        let minutes = Int(time) / 60 % 60
+        let minutes = Int(time) / 60
         let seconds = Int(time) % 60
         return (minutes: String(format: "%02d", minutes), seconds: String(format: "%02d", seconds))
     }

--- a/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 private enum Constants {
     static let progressBarSize = 300
-    static let selectedSeconds = 10
+    static let selectedSeconds = 30 * 60
 }
 
 final class SirenViewController: BaseViewController {

--- a/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
@@ -50,7 +50,6 @@ final class SirenViewController: BaseViewController {
         view.addSubview(progressBar)
         progressBar.snp.makeConstraints { make in
             make.center.equalTo(view)
-            make.size.equalTo(Constants.progressBarSize)
         }
 
         view.addSubview(doneLabel)

--- a/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/SirenViewController.swift
@@ -8,19 +8,22 @@
 import SnapKit
 import UIKit
 
+private enum Constants {
+    static let progressBarSize = 300
+    static let selectedSeconds = 10
+}
+
 final class SirenViewController: BaseViewController {
     // MARK: - Properties
 
     @IBOutlet var minutes: UILabel!
 
     @IBOutlet var seconds: UILabel!
-    // FIXME: - startButton은 임시코드
     @IBOutlet var startButton: UIButton!
     @IBOutlet var stopButton: UIButton!
-    @IBOutlet var progressBar: ProgressBar!
     @IBOutlet var counterView: UIStackView!
 
-    private let countdownTimer: CountDownTimer = .init()
+    private let countdownTimer: CountDownTimer = .init(totalSeconds: Constants.selectedSeconds)
 
     private let doneLabel: UILabel = {
         let label = UILabel()
@@ -33,7 +36,7 @@ final class SirenViewController: BaseViewController {
     }()
 
     private var countdownTimerDidStart = false
-    private let selectedSecs: Int = 30 * 60
+    private let progressBar: ProgressBar = .init(totalSeconds: Constants.selectedSeconds)
 
     // MARK: - Life Cycle
 
@@ -44,6 +47,12 @@ final class SirenViewController: BaseViewController {
     }
 
     override func render() {
+        view.addSubview(progressBar)
+        progressBar.snp.makeConstraints { make in
+            make.center.equalTo(view)
+            make.size.equalTo(Constants.progressBarSize)
+        }
+
         view.addSubview(doneLabel)
         doneLabel.snp.makeConstraints { make in
             make.center.equalToSuperview()
@@ -52,15 +61,15 @@ final class SirenViewController: BaseViewController {
 
     override func configUI() {
         super.configUI()
-        countdownTimer.setTimer(minutes: 0, seconds: selectedSecs)
-        progressBar.setProgressBar(minutes: 0, seconds: selectedSecs)
+        countdownTimer.setTimer()
         stopButton.isEnabled = false
         stopButton.alpha = 0.5
         doneLabel.isHidden = true
         counterView.isHidden = false
-
-        minutes.text = String(format: "%02d", selectedSecs / 60 % 60)
-        seconds.text = String(format: "%02d", selectedSecs % 60)
+        minutes.text = String(format: "%02d",
+                              Constants.selectedSeconds / 60)
+        seconds.text = String(format: "%02d",
+                              Constants.selectedSeconds % 60)
     }
 
     // MARK: - Func
@@ -75,8 +84,8 @@ final class SirenViewController: BaseViewController {
 
     @objc func addBackgroundTime(_ notification: Notification) {
         if countdownTimerDidStart == true {
-            let time = notification.userInfo?["time"] as? Int ?? 0
-            countdownTimer.duration -= Double(time)
+            let time = notification.userInfo?["time"] as? Double ?? 0.0
+            countdownTimer.duration -= time
         }
     }
 
@@ -124,5 +133,6 @@ extension SirenViewController: CountdownTimerDelegate {
         stopButton.alpha = 0.5
         startButton.setTitle("START", for: .normal)
         countdownTimerDidStart = false
+        progressBar.stop()
     }
 }

--- a/SecretAgent/SecretAgent/Screen/Siren/View/Component/ProgressBar.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/View/Component/ProgressBar.swift
@@ -23,8 +23,7 @@ final class ProgressBar: UIView, CAAnimationDelegate {
     private let foregroundProgressLayer: CAShapeLayer = .init()
     private let backgroundProgressLayer: CAShapeLayer = .init()
 
-    private lazy var centerPoint = CGPoint(x: frame.width / 2,
-                                           y: frame.height / 2)
+    private var centerPoint: CGPoint = .init(x: 0, y: 0)
 
     // MARK: - Init
 

--- a/SecretAgent/SecretAgent/Screen/Siren/View/Component/ProgressBar.swift
+++ b/SecretAgent/SecretAgent/Screen/Siren/View/Component/ProgressBar.swift
@@ -10,6 +10,8 @@ import UIKit
 private enum ProgressBarSize {
     static let startAngle = Double(-Double.pi / 2)
     static let endAngle = Double(3 * Double.pi / 2)
+    static let width = 300
+    static let height = 300
 }
 
 final class ProgressBar: UIView, CAAnimationDelegate {
@@ -26,33 +28,16 @@ final class ProgressBar: UIView, CAAnimationDelegate {
 
     // MARK: - Init
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
+    convenience init(totalSeconds: Int) {
+        self.init()
+        frame.size = .init(width: ProgressBarSize.width,
+                           height: ProgressBarSize.height)
+        timerDuration = totalSeconds
         loadBackgroundProgressBar()
         loadForegroundProgressBar()
     }
 
     // MARK: - Func
-
-    private func loadForegroundProgressBar() {
-        foregroundProgressLayer.path = UIBezierPath(
-            arcCenter: centerPoint,
-            radius: frame.width / 2 - 30.0,
-            startAngle: ProgressBarSize.startAngle,
-            endAngle: ProgressBarSize.endAngle,
-            clockwise: true
-        ).cgPath
-        foregroundProgressLayer.configProgressBar(
-            strokeColor: UIColor.blue.cgColor,
-            strokeEnd: 0.0
-        )
-        backgroundProgressLayer.addSublayer(foregroundProgressLayer)
-    }
 
     private func loadBackgroundProgressBar() {
         backgroundProgressLayer.path = UIBezierPath(
@@ -69,24 +54,28 @@ final class ProgressBar: UIView, CAAnimationDelegate {
         layer.addSublayer(backgroundProgressLayer)
     }
 
-    // 프로그래스바 설정
-    func setProgressBar(minutes: Int, seconds: Int) {
-        let minutesToSeconds = minutes * 60
-        let totalSeconds = seconds + minutesToSeconds
-        timerDuration = totalSeconds
+    private func loadForegroundProgressBar() {
+        foregroundProgressLayer.path = UIBezierPath(
+            arcCenter: centerPoint,
+            radius: frame.width / 2 - 30.0,
+            startAngle: ProgressBarSize.startAngle,
+            endAngle: ProgressBarSize.endAngle,
+            clockwise: true
+        ).cgPath
+        foregroundProgressLayer.configProgressBar(
+            strokeColor: UIColor.blue.cgColor,
+            strokeEnd: 0.0
+        )
+        backgroundProgressLayer.addSublayer(foregroundProgressLayer)
     }
 
     // 애니메이션 시작
     private func startAnimation() {
         resetAnimation()
         animation.keyPath = "strokeEnd"
-        animation.fromValue = 0.0
-        animation.toValue = 1.0
+        animation.fromValue = 1.0
+        animation.toValue = 0.0
         animation.duration = CFTimeInterval(timerDuration)
-        animation.delegate = self
-        animation.isRemovedOnCompletion = false
-        animation.isAdditive = true
-        animation.fillMode = CAMediaTimingFillMode.forwards
         foregroundProgressLayer.add(animation, forKey: "strokeEnd")
         animationDidStart = true
     }
@@ -143,7 +132,7 @@ final class ProgressBar: UIView, CAAnimationDelegate {
 
 // MARK: - CAShapeLayer
 
-extension CAShapeLayer {
+private extension CAShapeLayer {
     func configProgressBar(strokeColor: CGColor, strokeEnd: Double) {
         self.strokeColor = strokeColor
         backgroundColor = UIColor.clear.cgColor


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #12 
## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 타이머 종료 후 다시 시작버튼을 눌렀을 때 프로그래스 바의 애니메이션이 보이지 않는 버그를 해결했습니다.
- seconds의 이름을 totalSeconds로 바꾸었고 let으로 변경하였습니다.
- CountTimer와 ProgressBar에 생성자를 이용한 의존성 주입을 하였습니다. (totalSeconds)
- 이로 인해 ProgressBar가 기존의 스토리보드로 구현된 것을 코드베이스로 변경하였습니다.
- 백그라운드로 갈때와 포그라운드로 돌아올 때의 시간차이를 Int가 아니라 Double로 하여 소숫점 자리를 살려두어 오차를 줄였습니다.
- animation에 필요없는 코드들을 지웠습니다.
- 하나의 파일에만 사용되는 extension에 private을 추가하였습니다.
- 프로그래스바의 애니메이션을 채워진 상태에서 줄어들도록 변경했습니다.
## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
- PrgressBar에서 frame 설정을 하고나서 ViewController에서 오토레이아웃으로 위치만 center로 잡아주었는데 UI가 제대로 보여지지 않는 문제가 있었습니다. 그래서 오토레이아웃 작성하는 코드에 `progressBar.size.equalTo(300)`을 적용을 해주었더니 원하는 UI가 되었습니다. 사이즈 설정을 왜 두번을 해야되는지 아직 원인을 찾지 못했습니다.
- 코지가 제안해주신 scheduledTimer의 block 인자가 들어간 메서드로 코드를 수정해보았는데 또 다른 버그가 생겨서(스타트를 여러번 하면 시간간격이 점점 짧아지는 문제 발생) 기존의 코드로 일단 두었습니다.
