### PR TITLE
[FEAT] 보드 뷰와 CoreData 연결 

### DIFF
--- a/SecretAgent/SecretAgent/Global/Service/BadgeManager.swift
+++ b/SecretAgent/SecretAgent/Global/Service/BadgeManager.swift
@@ -5,8 +5,8 @@
 //  Created by JiwKang on 2022/11/23.
 //
 
-final class BadgeManger: CoreDataManager {
-    static let shared = BadgeManger()
+final class BadgeManager: CoreDataManager {
+    static let shared = BadgeManager()
     
     override private init() {}
     

--- a/SecretAgent/SecretAgent/Global/Support/AppDelegate.swift
+++ b/SecretAgent/SecretAgent/Global/Support/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // MARK: Core Data Init
 
-        BadgeManger.shared.initBadge()
+        BadgeManager.shared.initBadge()
         return true
     }
 

--- a/SecretAgent/SecretAgent/Screen/Board/View/BadgeCollectionViewCell.swift
+++ b/SecretAgent/SecretAgent/Screen/Board/View/BadgeCollectionViewCell.swift
@@ -16,7 +16,6 @@ private enum BadgeSize {
 class BadgeCollectionViewCell: UICollectionViewCell {
     // MARK: - Properties
 
-
     var badgeType: BadgeType = .coin
 
     private let badgeImageView = UIImageView()


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #23 

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
**CoreData**

- 상단의 뱃지 정보를 나타내고 뱃지 지도를 보여주기 위해 목데이터 대신 실제 `CoreData`를 반영하였습니다.
- 뱃지가 추가됐을 때 화면 변화 테스트를 위해 `tempButton`을 추가한 상태입니다. `tempButton`을 누르면 `CoreData`에 저장된 전체 코인 개수가 5개씩 증가합니다.

**기타**

- `BadgeManager`가 `BadgeManger`로 되어 있던 부분을 수정하였습니다.

![Simulator Screen Recording - iPhone 13 Pro - 2022-11-30 at 01 05 17](https://user-images.githubusercontent.com/78426896/204582579-566f518d-cfd3-44b2-b4c9-4a0d4686f7c2.gif)


## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
- 아무래도 이제는 속도를 올리느라 코드가 그리 깔끔하지 못한 것 같습니다.. 마음껏 불편한 부분 말씀해 주세요! 계속해서 고쳐 나가겠습니닷!

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 뱃지 업데이트 될 때 인터랙션 추가
 - [ ] 보드 뷰 UI 구현
