### PR TITLE
[FEAT] 7시 이후 첫 방문에만 정산하는 기능 구현

### DIFF
--- a/SecretAgent/SecretAgent/Global/Service/BadgeManager.swift
+++ b/SecretAgent/SecretAgent/Global/Service/BadgeManager.swift
@@ -49,24 +49,11 @@ final class BadgeManager: CoreDataManager {
     func updateTotalBadge() throws {
         let results = try fetchBadge()
         let currentBadge = results.first
-        let todaysCoin = Int(4) // 테스트를 하기 위한 코드입니다. 혹시나 하고 남겨요..
-//        let todaysCoin = Int(currentBadge?.coinsLeftForToday ?? 5)
+
+        let todaysCoin = Int(currentBadge?.coinsLeftForToday ?? 5)
         let totalCoin = Int(currentBadge?.numberOfTotalCoins ?? 0)
         
         currentBadge?.setValue(min(totalCoin + todaysCoin, 125), forKey: "numberOfTotalCoins")
-        
-        saveContext()
-    }
-    
-    // MARK: - 테스트를 하기 위해 임시로 추가한 코드입니다. 혹시나 하고 남겨요..
-
-    func testUpdateTotalBadge() throws {
-        let results = try fetchBadge()
-        let currentBadge = results.first
-        let todaysCoin = Int(5)
-        let totalCoin = Int(currentBadge?.numberOfTotalCoins ?? 0)
-        
-        currentBadge?.setValue(totalCoin - todaysCoin, forKey: "numberOfTotalCoins")
         
         saveContext()
     }

--- a/SecretAgent/SecretAgent/Global/Support/SceneDelegate.swift
+++ b/SecretAgent/SecretAgent/Global/Support/SceneDelegate.swift
@@ -44,6 +44,35 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let start = UserDefaults.standard.object(forKey: "sceneDidEnterBackground") as? Date else { return }
         let interval = Double(Date().timeIntervalSince(start))
         NotificationCenter.default.post(name: NSNotification.Name("sceneWillEnterForeground"), object: nil, userInfo: ["time": interval])
+        
+        // 이제부터 정산 드가자~
+        let currentDate = Date()
+        
+        let dayFormatter = DateFormatter()
+        dayFormatter.dateFormat = "d"
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateFormat = "HH"
+        
+        let currentDay: String = dayFormatter.string(from: currentDate)
+        let currentTime: String = timeFormatter.string(from: currentDate)
+
+        let pastDay: String = UserDefaults.standard.string(forKey: "day") ?? currentDay
+        let pastTime: String = UserDefaults.standard.string(forKey: "time") ?? currentTime
+        
+        UserDefaults.standard.setValue(currentTime, forKey: "time")
+        UserDefaults.standard.setValue(currentDay, forKey: "day")
+        
+        if pastDay != currentDay && pastTime.compare("07").rawValue >= 0 {
+            // 이렇게 해야 정산이 되더라
+            UserDefaults.standard.setValue(1, forKey: "todaysFirstVisit")
+            
+            let viewController = MainTabViewController()
+            viewController.selectedIndex = 0
+            window?.rootViewController = viewController
+        } else {
+            // 이거는 정산이 필요 없는 코드야
+            UserDefaults.standard.setValue(0, forKey: "todaysFirstVisit")
+        }
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/SecretAgent/SecretAgent/Screen/Board/View/BoardViewController.swift
+++ b/SecretAgent/SecretAgent/Screen/Board/View/BoardViewController.swift
@@ -420,16 +420,11 @@ final class BoardViewController: BaseViewController {
 
     @objc func testDecreaseBadgeNumber() {
         do {
-            try BadgeManager.shared.testUpdateTotalBadge()
-            do {
-                let getBadgeNumberFromCoreData = try BadgeManager.shared.numberOfTotalCoins()
-                totalBadgeNumber = getBadgeNumberFromCoreData.result
-                totalBadgeNumberFromCoreData = getBadgeNumberFromCoreData.result
-                updateBadgeInformation()
-                refreshBoard(targetIndex: min(totalBadgeNumberFromCoreData / 25, 4))
-            } catch {
-                print(error)
-            }
+            let getBadgeNumberFromCoreData = try BadgeManager.shared.numberOfTotalCoins()
+            totalBadgeNumber = getBadgeNumberFromCoreData.result
+            totalBadgeNumberFromCoreData = getBadgeNumberFromCoreData.result
+            updateBadgeInformation()
+            refreshBoard(targetIndex: min(totalBadgeNumberFromCoreData / 25, 4))
         } catch {
             print(error)
         }

--- a/SecretAgent/SecretAgent/Screen/Board/View/BoardViewController.swift
+++ b/SecretAgent/SecretAgent/Screen/Board/View/BoardViewController.swift
@@ -167,6 +167,11 @@ final class BoardViewController: BaseViewController {
             allStarsCollected = true
         }
         refreshBoard(targetIndex: getLatestTableViewIndex())
+        
+        if UserDefaults.standard.integer(forKey: "todaysFirstVisit") == 1 {
+            receiveTodaysBadges()
+            UserDefaults.standard.setValue(0, forKey: "todaysFirstVisit")
+        }
     }
 
     override func render() {
@@ -365,7 +370,6 @@ final class BoardViewController: BaseViewController {
 
         // 코어데이터에 반영하기
         do {
-            try BadgeManager.shared.resetTodaysBadge()
             try BadgeManager.shared.updateTotalBadge()
             do {
                 let getBadgeNumberFromCoreData = try BadgeManager.shared.numberOfTotalCoins()
@@ -379,6 +383,8 @@ final class BoardViewController: BaseViewController {
 
                 todaysBadgeNumber = try BadgeManager.shared.coinsLeftForToday().result
                 updatedTotalBadge = try BadgeManager.shared.numberOfTotalCoins().result
+                
+                try BadgeManager.shared.resetTodaysBadge()
             } catch {
                 print("error")
             }


### PR DESCRIPTION
## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
* 7시 이후 첫 방문 시 정산하도록 구현하였음
* 이전 날짜, 이전 시간, 현재 날짜, 현재 시간을 비교하여 정산하도록 하였습니다.
* 정산해야한다고 판단이 되면 board뷰로 이동한 다음 오늘 처음 뷰를 켰다는 판단을 한 후 정산을 한다. 그리고 오늘 받을 뱃지를 초기화 한다.

## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
* 편하게 물어보세요~

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 다음으로 할 일을 적어주세요.
